### PR TITLE
Use the faster Buf.append instead of ~=

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Compress::Zlib",
-    "version" : "1.0.0",
+    "version" : "1.1.0",
     "author" : "github:retupmoca",
     "description" : "Nicer zlib interface",
     "depends" : ["Compress::Zlib::Raw"],

--- a/lib/Compress/Zlib.pm6
+++ b/lib/Compress/Zlib.pm6
@@ -43,14 +43,6 @@ our sub uncompress(Blob $data --> Buf) is export {
     _internal-compression($data, False);
 }
 
-sub _buf-chop($buf is rw, $length) {
-    nqp::splice(nqp::decont($buf), nqp::decont(buf8.new()), $length, $buf.elems - $length);
-}
-
-sub _buf-append($bufa is rw, $bufb) {
-    nqp::splice(nqp::decont($bufa), nqp::decont($bufb), $bufa.elems, 0);
-}
-
 class Compress::Zlib::Stream {
     has $!z-stream;
     has $!gz-header;
@@ -102,8 +94,8 @@ class Compress::Zlib::Stream {
                 fail "Cannot inflate stream: $!z-stream.msg()";
             }
 
-            _buf-chop($output-buf, 8192 - $!z-stream.avail-out);
-            _buf-append($out, $output-buf);
+            $output-buf.reallocate(8192 - $!z-stream.avail-out);
+            $out.append($output-buf);
             #$out ~= $output-buf.subbuf(0, 8192 - $!z-stream.avail-out);
 
             if $ret == Compress::Zlib::Raw::Z_STREAM_END {
@@ -152,8 +144,8 @@ class Compress::Zlib::Stream {
                 fail "Cannot deflate stream: $!z-stream.msg()";
             }
 
-            _buf-chop($output-buf, 8192 - $!z-stream.avail-out);
-            _buf-append($out, $output-buf);
+            $output-buf.reallocate(8192 - $!z-stream.avail-out);
+            $out.append($output-buf);
             #$out ~= $output-buf.subbuf(0, 8192 - $!z-stream.avail-out);
 
             if $!z-stream.avail-out && !($!z-stream.avail-in) {

--- a/lib/Compress/Zlib.pm6
+++ b/lib/Compress/Zlib.pm6
@@ -266,7 +266,7 @@ class Compress::Zlib::Wrap {
 
             my $c = $.handle.read($chunksize);
             fail "Unable to read from handle" unless $c;
-            $!read-buffer ~= $!decompressor.inflate($c);
+            $!read-buffer.append($!decompressor.inflate($c));
         }
     }
 
@@ -298,7 +298,7 @@ class Compress::Zlib::Wrap {
                 return $ret;
             }
             fail "Unable to read from handle" unless $c;
-            $!read-buffer ~= $!decompressor.inflate($c);
+            $!read-buffer.append($!decompressor.inflate($c));
         }
 
         my $ret = $!read-buffer.subbuf(0,$size);
@@ -367,7 +367,7 @@ class Compress::Zlib::Wrap {
             my $Buf = buf8.new();
             loop {
                 my $current  = self.read(10_000);
-                $Buf ~= $current;
+                $Buf.append($current);
                 last if $current.bytes == 0;
             }
             self.close;

--- a/lib/Compress/Zlib.pm6
+++ b/lib/Compress/Zlib.pm6
@@ -77,10 +77,11 @@ class Compress::Zlib::Stream {
         $!z-stream.set-input($data);
 
         my $out = buf8.new;
+        my $output-buf = buf8.new;
 
         loop {
-            my $output-buf = buf8.new;
-            $output-buf[8191] = 1;
+            $output-buf.reallocate(0);
+            $output-buf.reallocate(8192);
             $!z-stream.set-output($output-buf);
 
             unless $!inflate-init {
@@ -120,10 +121,11 @@ class Compress::Zlib::Stream {
         $!z-stream.set-input($data);
 
         my $out = buf8.new;
+        my $output-buf = buf8.new;
 
         loop {
-            my $output-buf = buf8.new;
-            $output-buf[8191] = 1;
+            $output-buf.reallocate(0);
+            $output-buf.reallocate(8192);
             $!z-stream.set-output($output-buf);
 
             unless $!deflate-init {
@@ -256,7 +258,7 @@ class Compress::Zlib::Wrap {
             if $!decompressor.finished || self.eof {
                 return Str unless $!read-buffer.elems;
                 my $ret = $!read-buffer.decode;
-                $!read-buffer = Buf.new;
+                $!read-buffer.reallocate(0);
                 return $ret;
             }
 
@@ -290,7 +292,7 @@ class Compress::Zlib::Wrap {
             my $c = $.handle.read($size);
             unless $c.elems {
                 my $ret = $!read-buffer;
-                $!read-buffer = Buf.new;
+                $!read-buffer.reallocate(0);
                 return $ret;
             }
             fail "Unable to read from handle" unless $c;

--- a/lib/Compress/Zlib.pm6
+++ b/lib/Compress/Zlib.pm6
@@ -213,6 +213,7 @@ class Compress::Zlib::Wrap {
     has Buf $!read-buffer = Buf.new;
     has $!nl = "\n";
     has int $!nl-chars;
+    has $!encoder;
 
     method new($handle, :$zlib, :$deflate, :$gzip){
         self.bless(:$handle, :$zlib, :$deflate, :$gzip);
@@ -221,6 +222,7 @@ class Compress::Zlib::Wrap {
     submethod BUILD(:$!handle, :$zlib, :$deflate, :$gzip) {
         $!compressor = Compress::Zlib::Stream.new(:$zlib, :$gzip, :$deflate);
         $!decompressor = Compress::Zlib::Stream.new(:$zlib, :$gzip, :$deflate);
+        $!encoder = Encoding::Registry.find('utf8').encoder;
     }
 
     submethod TWEAK() {
@@ -251,7 +253,7 @@ class Compress::Zlib::Wrap {
             my $i = $bufstr.index($!nl);
             if $i.defined {
                 my $ret = $bufstr.substr(0,$i+$!nl-chars);
-                $!read-buffer = $!read-buffer.subbuf($ret.encode.bytes);
+                $!read-buffer .= subbuf($!encoder.encode-chars($ret).bytes);
                 return $ret;
             }
 


### PR DESCRIPTION
On my machine this is **much** faster and uses a **lot** less ram. For a 4.9m gzip file that unzips to 17m, just gzslurping it (with `:bin`) decreased from ~9.5s and 6012364maxresident to ~0.7s and 155352maxresident. For the not `:bin` case, gzslurping it decreases from ~9.5s to ~7s.

Passes all the tests.