### PR TITLE
Speedup gzslurp and .lines

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Compress::Zlib",
-    "version" : "1.1.0",
+    "version" : "1.2.0",
     "author" : "github:retupmoca",
     "description" : "Nicer zlib interface",
     "depends" : ["Compress::Zlib::Raw"],


### PR DESCRIPTION
When doing a gzslurp not in binary mode, instead of joining the .lines,
just decode the binary.

Also speedup .lines by adapting code from IO::Handle to directly use an
Encoding::Decoder in .get.

Also, fix a bug in .read. Before the last bit of a file would be left
off if it took more than one .read call to load the whole thing.

All the tests pass. This example `use Compress::Zlib; my $a = zwrap(open("100k.txt.gz"), :gzip); say $a.lines.elems'` used to take ~3.2s and now takes ~1.5s and `use Compress::Zlib; my $a = gzslurp("100k.txt.gz"); say $a.chars` used to take ~3.2s and now takes ~0.7s (where "100k.txt.gz" is a text file with 100k lines that's 2mb compressed and 6.8mb decompressed). 